### PR TITLE
Fix nový-lkod-nejen-pro-prahu.md odkaz na obrázek

### DIFF
--- a/_clanky/nový-lkod-nejen-pro-prahu.md
+++ b/_clanky/nový-lkod-nejen-pro-prahu.md
@@ -4,7 +4,7 @@ detail: true
 title: "Nový lokální katalog otevřených dat nabízí řešení nejen pro Prahu. Zdarma přes něj mohou svá data publikovat i další"
 ref: nový-lkod-nejen-pro-prahu
 lang: cs 
-image: přílohy/články/nový-lkod-nejen-pro-prahu/lkod-praha.webp
+image: ../přílohy/články/nový-lkod-nejen-pro-prahu/lkod-praha.webp
 author: marie_čermáková
 date: 2024-01-4 12:00:00 +02:00 
 --- 


### PR DESCRIPTION
Na https://data.gov.cz/články dostávám 404 kvůli requestu na `https://data.gov.cz/články/přílohy/články/nový-lkod-nejen-pro-prahu/lkod-praha.webp`, což by se mělo opravit na `https://data.gov.cz/přílohy/články/nový-lkod-nejen-pro-prahu/lkod-praha.webp`, proto do odkazu přidávám `../`