### PR TITLE
Fix data-jsou-základ-lepších-služeb.md odkaz na proc-potrebujeme-data.pdf

### DIFF
--- a/_clanky/data-jsou-základ-lepších-služeb.md
+++ b/_clanky/data-jsou-základ-lepších-služeb.md
@@ -99,4 +99,4 @@ V různých segmentech budou postupně vznikat tzv. datové prostory ([Data Sp
 [na stránce s výstupy projektu]: /kodi/ "Výstupy projektu Kodi"
 [Věcný záměr tohoto zákona]: https://odok.cz/portal/veklep/material/ALBSCL8DQ7VJ/ "ODok Věcný záměr zákona o správě dat veřejného sektoru"
 [Data Spaces]: https://dssc.eu/space/SK/32407574/1+Data+Spaces+101 "Data Spaces 101"
-[proč jsou data důležitá]: přílohy/články/data-jsou-základ-lepších-služeb/proc-potrebujeme-data.pdf "Proč potřebujeme data"
+[proč jsou data důležitá]: ../přílohy/články/data-jsou-základ-lepších-služeb/proc-potrebujeme-data.pdf "Proč potřebujeme data"


### PR DESCRIPTION
Stejný typ problému, jako v PR #380. Odkaz místo na `https://data.gov.cz/přílohy/články/data-jsou-základ-lepších-služeb/proc-potrebujeme-data.pdf` odkazuje na `https://data.gov.cz/články/přílohy/články/data-jsou-základ-lepších-služeb/proc-potrebujeme-data.pdf`. cc @jakubklimek @lenkakovacova89 